### PR TITLE
Parse all AAL files when looking for node names

### DIFF
--- a/magi/util/helpers.py
+++ b/magi/util/helpers.py
@@ -201,7 +201,7 @@ def getNodesFromAAL(filenames):
             read_data = True
 
     if read_data:
-        print('concat AAL: {}'.format(yaml_file.getvalue()))
+        log.debug('concat AAL: {}'.format(yaml_file.getvalue()))
         aaldata = yaml.load(yaml_file.getvalue())
         for nodes in aaldata['groups'].values():
             nodeSet.update(nodes)

--- a/magi/util/helpers.py
+++ b/magi/util/helpers.py
@@ -7,6 +7,7 @@ import os
 import platform
 import yaml
 import tarfile
+import cStringIO
 
 log = logging.getLogger(__name__)
 
@@ -189,11 +190,22 @@ def loadIDL(agentName, expProcdureFile):
 
 def getNodesFromAAL(filenames):
     nodeSet = set()
-    if filenames:
-        for filename in toSet(filenames):
-            aaldata = loadYaml(filename)
-            for nodes in aaldata['groups'].values():
-                nodeSet.update(nodes)
+
+    # GTL We need to merge the AALs to parse them correctly as there my be anchors
+    #  and rerferences across the files!
+    yaml_file = cStringIO.StringIO()
+    read_data = False
+    for f in filenames:  # do NOT change order of filenames!
+        with open(f) as fd:
+            yaml_file.write(fd.read())
+            read_data = True
+
+    if read_data:
+        print('concat AAL: {}'.format(yaml_file.getvalue()))
+        aaldata = yaml.load(yaml_file.getvalue())
+        for nodes in aaldata['groups'].values():
+            nodeSet.update(nodes)
+
     return nodeSet
 
 def getExperimentConfigFile(project, experiment):

--- a/scripts/magi_orchestrator.py
+++ b/scripts/magi_orchestrator.py
@@ -3,6 +3,7 @@
 from magi.messaging import api
 from magi.orchestrator import AAL, Orchestrator
 from magi.orchestrator.parse import AALParseError
+from magi import __version__
 from socket import gaierror # this should really be wrapped in daemon lib.
 from sys import exit
 
@@ -107,10 +108,18 @@ if __name__ == '__main__':
                          dest="justparse",
                          help="Parse and display the procedure file specified with -f",
                          default=False,
-                         action="store_true")
+                         action="store_true"),
+    optparser.add_option('-V', '--version',
+                         dest='version',
+                         help='Give Magi version and exit',
+                         default=False,
+                         action='store_true')
 
     (options, args) = optparser.parse_args()
 
+    if options.version:
+        print('Magi Version: {}'.format(__version__))
+        exit(0)
 
     if not options.events:
         options.error("Missing events file")


### PR DESCRIPTION
The magi orchestrator can take multiple AAL files on the command line. EdgeCT uses this to separate experiment instantiation from execution details. (i.e. node names are in one AAL and agent calls are in another.) This way, we can reuse AALs across different experiments with different topologies and node names. To do this we use YAML anchors and references across the different files. The anchor is declared in the nodes.aal and the execution aal references that anchor to build the group. 

The current implementation of Orchestrator breaks if the AALs contain anchors and references. It breaks when pulling node names from the AALs in getNodesFromAAL() as that code assumes each AAL file can be parsed alone. This is not true with references as the anchor is in another file. So this patch joins all AALs together before parsing. This is nearly identical code to what's already in the AAL class and accomplishes the same thing. 

This patch has been tested with the EdgeCT scenarios we're developing and it works. 

If you accept this pull request, I'll update EdgeCTs Magi and have OPs install the updated library on users. 